### PR TITLE
Errors handling during COPY FROM

### DIFF
--- a/contrib/file_fdw/file_fdw.c
+++ b/contrib/file_fdw/file_fdw.c
@@ -689,7 +689,7 @@ fileIterateForeignScan(ForeignScanState *node)
 {
 	FileFdwExecutionState *festate = (FileFdwExecutionState *) node->fdw_state;
 	TupleTableSlot *slot = node->ss.ss_ScanTupleSlot;
-	bool		found;
+	int		found;
 	ErrorContextCallback errcallback;
 
 	/* Set up callback to identify error line number. */
@@ -1080,7 +1080,7 @@ file_acquire_sample_rows(Relation onerel, int elevel,
 	TupleDesc	tupDesc;
 	Datum	   *values;
 	bool	   *nulls;
-	bool		found;
+	int		    found;
 	char	   *filename;
 	bool		is_program;
 	List	   *options;

--- a/doc/src/sgml/ref/copy.sgml
+++ b/doc/src/sgml/ref/copy.sgml
@@ -44,6 +44,7 @@ COPY { <replaceable class="parameter">table_name</replaceable> [ ( <replaceable 
     FORCE_NOT_NULL ( <replaceable class="parameter">column_name</replaceable> [, ...] )
     FORCE_NULL ( <replaceable class="parameter">column_name</replaceable> [, ...] )
     ENCODING '<replaceable class="parameter">encoding_name</replaceable>'
+    IGNORE_ERRORS [ <replaceable class="parameter">boolean</replaceable> ]
 </synopsis>
  </refsynopsisdiv>
 
@@ -244,6 +245,17 @@ COPY { <replaceable class="parameter">table_name</replaceable> [ ( <replaceable 
       a comma in <literal>CSV</literal> format.
       This must be a single one-byte character.
       This option is not allowed when using <literal>binary</literal> format.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term><literal>IGNORE_ERRORS</literal></term>
+    <listitem>
+     <para>
+      Specifies ignoring errors in the input data. If TRUE, then all
+      errors due to the extra or missing columns and inappropriate type
+      format will be ignored with WARNING.
      </para>
     </listitem>
    </varlistentry>

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -54,6 +54,16 @@
 #define OCTVALUE(c) ((c) - '0')
 
 /*
+    NextCopyFrom states:
+    0 – Error or stop
+    1 – Successfully read data
+    2 – Data with errors, skip
+*/
+#define NCF_STOP         0
+#define NCF_SUCCESS      1
+#define NCF_SKIP         2
+
+/*
  * Represents the different source/dest cases we need to worry about at
  * the bottom level
  */
@@ -139,6 +149,7 @@ typedef struct CopyStateData
 	int			cur_lineno;		/* line number for error messages */
 	const char *cur_attname;	/* current att for error messages */
 	const char *cur_attval;		/* current att value for error messages */
+    bool        ignore_errors;  /* ignore errors during COPY FROM */
 
 	/*
 	 * Working state for COPY TO/FROM
@@ -1202,6 +1213,15 @@ ProcessCopyOptions(ParseState *pstate,
 						 errmsg("argument to option \"%s\" must be a valid encoding name",
 								defel->defname),
 						 parser_errposition(pstate, defel->location)));
+		}
+		else if (strcmp(defel->defname, "ignore_errors") == 0)
+		{
+			if (cstate->ignore_errors)
+				ereport(ERROR,
+						(errcode(ERRCODE_SYNTAX_ERROR),
+						 errmsg("conflicting or redundant options"),
+						 parser_errposition(pstate, defel->location)));
+			cstate->ignore_errors = defGetBoolean(defel);
 		}
 		else
 			ereport(ERROR,
@@ -2300,6 +2320,7 @@ CopyFrom(CopyState cstate)
 	bool		useHeapMultiInsert;
 	int			nBufferedTuples = 0;
 	int			prev_leaf_part_index = -1;
+    int         next_cf_state; /* NextCopyFrom return state */
 
 #define MAX_BUFFERED_TUPLES 1000
 	HeapTuple  *bufferedTuples = NULL;	/* initialize to silence warning */
@@ -2580,146 +2601,155 @@ CopyFrom(CopyState cstate)
 		/* Switch into its memory context */
 		MemoryContextSwitchTo(GetPerTupleMemoryContext(estate));
 
-		if (!NextCopyFrom(cstate, econtext, values, nulls, &loaded_oid))
+        next_cf_state = NextCopyFrom(cstate, econtext, values, nulls, &loaded_oid);
+
+		if (!next_cf_state) {
 			break;
-
-		/* And now we can form the input tuple. */
-		tuple = heap_form_tuple(tupDesc, values, nulls);
-
-		if (loaded_oid != InvalidOid)
-			HeapTupleSetOid(tuple, loaded_oid);
-
-		/*
-		 * Constraints might reference the tableoid column, so initialize
-		 * t_tableOid before evaluating them.
-		 */
-		tuple->t_tableOid = RelationGetRelid(resultRelInfo->ri_RelationDesc);
-
-		/* Triggers and stuff need to be invoked in query context. */
-		MemoryContextSwitchTo(oldcontext);
-
-		/* Place tuple in tuple slot --- but slot shouldn't free it */
-		slot = myslot;
-		ExecStoreTuple(tuple, slot, InvalidBuffer, false);
-
-		/* Determine the partition to heap_insert the tuple into */
-		if (cstate->partition_dispatch_info)
-		{
-			int			leaf_part_index;
-			TupleConversionMap *map;
-
-			/*
-			 * Away we go ... If we end up not finding a partition after all,
-			 * ExecFindPartition() does not return and errors out instead.
-			 * Otherwise, the returned value is to be used as an index into
-			 * arrays mt_partitions[] and mt_partition_tupconv_maps[] that
-			 * will get us the ResultRelInfo and TupleConversionMap for the
-			 * partition, respectively.
-			 */
-			leaf_part_index = ExecFindPartition(resultRelInfo,
-												cstate->partition_dispatch_info,
-												slot,
-												estate);
-			Assert(leaf_part_index >= 0 &&
-				   leaf_part_index < cstate->num_partitions);
-
-			/*
-			 * If this tuple is mapped to a partition that is not same as the
-			 * previous one, we'd better make the bulk insert mechanism gets a
-			 * new buffer.
-			 */
-			if (prev_leaf_part_index != leaf_part_index)
-			{
-				ReleaseBulkInsertStatePin(bistate);
-				prev_leaf_part_index = leaf_part_index;
-			}
-
-			/*
-			 * Save the old ResultRelInfo and switch to the one corresponding
-			 * to the selected partition.
-			 */
-			saved_resultRelInfo = resultRelInfo;
-			resultRelInfo = cstate->partitions[leaf_part_index];
-
-			/* We do not yet have a way to insert into a foreign partition */
-			if (resultRelInfo->ri_FdwRoutine)
-				ereport(ERROR,
-						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						 errmsg("cannot route inserted tuples to a foreign table")));
-
-			/*
-			 * For ExecInsertIndexTuples() to work on the partition's indexes
-			 */
-			estate->es_result_relation_info = resultRelInfo;
-
-			/*
-			 * If we're capturing transition tuples, we might need to convert
-			 * from the partition rowtype to parent rowtype.
-			 */
-			if (cstate->transition_capture != NULL)
-			{
-				if (resultRelInfo->ri_TrigDesc &&
-					(resultRelInfo->ri_TrigDesc->trig_insert_before_row ||
-					 resultRelInfo->ri_TrigDesc->trig_insert_instead_row))
-				{
-					/*
-					 * If there are any BEFORE or INSTEAD triggers on the
-					 * partition, we'll have to be ready to convert their
-					 * result back to tuplestore format.
-					 */
-					cstate->transition_capture->tcs_original_insert_tuple = NULL;
-					cstate->transition_capture->tcs_map =
-						cstate->transition_tupconv_maps[leaf_part_index];
-				}
-				else
-				{
-					/*
-					 * Otherwise, just remember the original unconverted
-					 * tuple, to avoid a needless round trip conversion.
-					 */
-					cstate->transition_capture->tcs_original_insert_tuple = tuple;
-					cstate->transition_capture->tcs_map = NULL;
-				}
-			}
-
-			/*
-			 * We might need to convert from the parent rowtype to the
-			 * partition rowtype.
-			 */
-			map = cstate->partition_tupconv_maps[leaf_part_index];
-			if (map)
-			{
-				Relation	partrel = resultRelInfo->ri_RelationDesc;
-
-				tuple = do_convert_tuple(tuple, map);
-
-				/*
-				 * We must use the partition's tuple descriptor from this
-				 * point on.  Use a dedicated slot from this point on until
-				 * we're finished dealing with the partition.
-				 */
-				slot = cstate->partition_tuple_slot;
-				Assert(slot != NULL);
-				ExecSetSlotDescriptor(slot, RelationGetDescr(partrel));
-				ExecStoreTuple(tuple, slot, InvalidBuffer, true);
-			}
-
-			tuple->t_tableOid = RelationGetRelid(resultRelInfo->ri_RelationDesc);
 		}
+        else if (next_cf_state == NCF_SUCCESS)
+        {
+    		/* And now we can form the input tuple. */
+    		tuple = heap_form_tuple(tupDesc, values, nulls);
 
-		skip_tuple = false;
+    		if (loaded_oid != InvalidOid)
+    			HeapTupleSetOid(tuple, loaded_oid);
 
-		/* BEFORE ROW INSERT Triggers */
-		if (resultRelInfo->ri_TrigDesc &&
-			resultRelInfo->ri_TrigDesc->trig_insert_before_row)
-		{
-			slot = ExecBRInsertTriggers(estate, resultRelInfo, slot);
+    		/*
+    		 * Constraints might reference the tableoid column, so initialize
+    		 * t_tableOid before evaluating them.
+    		 */
+    		tuple->t_tableOid = RelationGetRelid(resultRelInfo->ri_RelationDesc);
 
-			if (slot == NULL)	/* "do nothing" */
-				skip_tuple = true;
-			else				/* trigger might have changed tuple */
-				tuple = ExecMaterializeSlot(slot);
-		}
+    		/* Triggers and stuff need to be invoked in query context. */
+    		MemoryContextSwitchTo(oldcontext);
+
+    		/* Place tuple in tuple slot --- but slot shouldn't free it */
+    		slot = myslot;
+    		ExecStoreTuple(tuple, slot, InvalidBuffer, false);
+
+    		/* Determine the partition to heap_insert the tuple into */
+    		if (cstate->partition_dispatch_info)
+    		{
+    			int			leaf_part_index;
+    			TupleConversionMap *map;
+
+    			/*
+    			 * Away we go ... If we end up not finding a partition after all,
+    			 * ExecFindPartition() does not return and errors out instead.
+    			 * Otherwise, the returned value is to be used as an index into
+    			 * arrays mt_partitions[] and mt_partition_tupconv_maps[] that
+    			 * will get us the ResultRelInfo and TupleConversionMap for the
+    			 * partition, respectively.
+    			 */
+    			leaf_part_index = ExecFindPartition(resultRelInfo,
+    												cstate->partition_dispatch_info,
+    												slot,
+    												estate);
+    			Assert(leaf_part_index >= 0 &&
+    				   leaf_part_index < cstate->num_partitions);
+
+    			/*
+    			 * If this tuple is mapped to a partition that is not same as the
+    			 * previous one, we'd better make the bulk insert mechanism gets a
+    			 * new buffer.
+    			 */
+    			if (prev_leaf_part_index != leaf_part_index)
+    			{
+    				ReleaseBulkInsertStatePin(bistate);
+    				prev_leaf_part_index = leaf_part_index;
+    			}
+
+    			/*
+    			 * Save the old ResultRelInfo and switch to the one corresponding
+    			 * to the selected partition.
+    			 */
+    			saved_resultRelInfo = resultRelInfo;
+    			resultRelInfo = cstate->partitions[leaf_part_index];
+
+    			/* We do not yet have a way to insert into a foreign partition */
+    			if (resultRelInfo->ri_FdwRoutine)
+    				ereport(ERROR,
+    						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+    						 errmsg("cannot route inserted tuples to a foreign table")));
+
+    			/*
+    			 * For ExecInsertIndexTuples() to work on the partition's indexes
+    			 */
+    			estate->es_result_relation_info = resultRelInfo;
+
+    			/*
+    			 * If we're capturing transition tuples, we might need to convert
+    			 * from the partition rowtype to parent rowtype.
+    			 */
+    			if (cstate->transition_capture != NULL)
+    			{
+    				if (resultRelInfo->ri_TrigDesc &&
+    					(resultRelInfo->ri_TrigDesc->trig_insert_before_row ||
+    					 resultRelInfo->ri_TrigDesc->trig_insert_instead_row))
+    				{
+    					/*
+    					 * If there are any BEFORE or INSTEAD triggers on the
+    					 * partition, we'll have to be ready to convert their
+    					 * result back to tuplestore format.
+    					 */
+    					cstate->transition_capture->tcs_original_insert_tuple = NULL;
+    					cstate->transition_capture->tcs_map =
+    						cstate->transition_tupconv_maps[leaf_part_index];
+    				}
+    				else
+    				{
+    					/*
+    					 * Otherwise, just remember the original unconverted
+    					 * tuple, to avoid a needless round trip conversion.
+    					 */
+    					cstate->transition_capture->tcs_original_insert_tuple = tuple;
+    					cstate->transition_capture->tcs_map = NULL;
+    				}
+    			}
+
+    			/*
+    			 * We might need to convert from the parent rowtype to the
+    			 * partition rowtype.
+    			 */
+    			map = cstate->partition_tupconv_maps[leaf_part_index];
+    			if (map)
+    			{
+    				Relation	partrel = resultRelInfo->ri_RelationDesc;
+
+    				tuple = do_convert_tuple(tuple, map);
+
+    				/*
+    				 * We must use the partition's tuple descriptor from this
+    				 * point on.  Use a dedicated slot from this point on until
+    				 * we're finished dealing with the partition.
+    				 */
+    				slot = cstate->partition_tuple_slot;
+    				Assert(slot != NULL);
+    				ExecSetSlotDescriptor(slot, RelationGetDescr(partrel));
+    				ExecStoreTuple(tuple, slot, InvalidBuffer, true);
+    			}
+
+    			tuple->t_tableOid = RelationGetRelid(resultRelInfo->ri_RelationDesc);
+    		}
+
+    		skip_tuple = false;
+
+    		/* BEFORE ROW INSERT Triggers */
+    		if (resultRelInfo->ri_TrigDesc &&
+    			resultRelInfo->ri_TrigDesc->trig_insert_before_row)
+    		{
+    			slot = ExecBRInsertTriggers(estate, resultRelInfo, slot);
+
+    			if (slot == NULL)	/* "do nothing" */
+    				skip_tuple = true;
+    			else				/* trigger might have changed tuple */
+    				tuple = ExecMaterializeSlot(slot);
+    		}
+        }
+        else
+        {
+            skip_tuple = true;
+        }
 
 		if (!skip_tuple)
 		{
@@ -3294,7 +3324,7 @@ NextCopyFromRawFields(CopyState cstate, char ***fields, int *nfields)
  * relation passed to BeginCopyFrom. This function fills the arrays.
  * Oid of the tuple is returned with 'tupleOid' separately.
  */
-bool
+int
 NextCopyFrom(CopyState cstate, ExprContext *econtext,
 			 Datum *values, bool *nulls, Oid *tupleOid)
 {
@@ -3311,10 +3341,20 @@ NextCopyFrom(CopyState cstate, ExprContext *econtext,
 	int		   *defmap = cstate->defmap;
 	ExprState **defexprs = cstate->defexprs;
 
+    /* Error level for COPY FROM input data errors */
+    int         error_level = ERROR;
+    MemoryContext oldcontext = CurrentMemoryContext;
+
 	tupDesc = RelationGetDescr(cstate->rel);
 	num_phys_attrs = tupDesc->natts;
 	attr_count = list_length(cstate->attnumlist);
 	nfields = file_has_oids ? (attr_count + 1) : attr_count;
+
+    /* Set error level to WARNING, if errors handling is turned on */
+    if (cstate->ignore_errors)
+    {
+        error_level = WARNING;
+    }
 
 	/* Initialize all values for row to NULL */
 	MemSet(values, 0, num_phys_attrs * sizeof(Datum));
@@ -3330,13 +3370,17 @@ NextCopyFrom(CopyState cstate, ExprContext *econtext,
 
 		/* read raw fields in the next line */
 		if (!NextCopyFromRawFields(cstate, &field_strings, &fldct))
-			return false;
+			return NCF_STOP;
 
 		/* check for overflowing fields */
 		if (nfields > 0 && fldct > nfields)
-			ereport(ERROR,
+        {
+			ereport(error_level,
 					(errcode(ERRCODE_BAD_COPY_FILE_FORMAT),
-					 errmsg("extra data after last expected column")));
+					 errmsg("extra data after last expected column at line %d", cstate->cur_lineno)));
+            return NCF_SKIP;
+        }
+
 
 		fieldno = 0;
 
@@ -3344,15 +3388,22 @@ NextCopyFrom(CopyState cstate, ExprContext *econtext,
 		if (file_has_oids)
 		{
 			if (fieldno >= fldct)
-				ereport(ERROR,
+            {
+				ereport(error_level,
 						(errcode(ERRCODE_BAD_COPY_FILE_FORMAT),
-						 errmsg("missing data for OID column")));
+						 errmsg("missing data for OID column at line %d", cstate->cur_lineno)));
+                return NCF_SKIP;
+            }
+
 			string = field_strings[fieldno++];
 
 			if (string == NULL)
-				ereport(ERROR,
+            {
+				ereport(error_level,
 						(errcode(ERRCODE_BAD_COPY_FILE_FORMAT),
-						 errmsg("null OID in COPY data")));
+						 errmsg("null OID in COPY data at line %d", cstate->cur_lineno)));
+                return NCF_SKIP;
+            }
 			else if (cstate->oids && tupleOid != NULL)
 			{
 				cstate->cur_attname = "oid";
@@ -3360,9 +3411,13 @@ NextCopyFrom(CopyState cstate, ExprContext *econtext,
 				*tupleOid = DatumGetObjectId(DirectFunctionCall1(oidin,
 																 CStringGetDatum(string)));
 				if (*tupleOid == InvalidOid)
-					ereport(ERROR,
+                {
+					ereport(error_level,
 							(errcode(ERRCODE_BAD_COPY_FILE_FORMAT),
-							 errmsg("invalid OID in COPY data")));
+							 errmsg("invalid OID in COPY data at line %d", cstate->cur_lineno)));
+                    return NCF_SKIP;
+                }
+
 				cstate->cur_attname = NULL;
 				cstate->cur_attval = NULL;
 			}
@@ -3376,10 +3431,14 @@ NextCopyFrom(CopyState cstate, ExprContext *econtext,
 			Form_pg_attribute att = TupleDescAttr(tupDesc, m);
 
 			if (fieldno >= fldct)
-				ereport(ERROR,
+            {
+				ereport(error_level,
 						(errcode(ERRCODE_BAD_COPY_FILE_FORMAT),
-						 errmsg("missing data for column \"%s\"",
-								NameStr(att->attname))));
+						 errmsg("missing data for column \"%s\" at line %d",
+								NameStr(att->attname), cstate->cur_lineno)));
+                return NCF_SKIP;
+            }
+
 			string = field_strings[fieldno++];
 
 			if (cstate->convert_select_flags &&
@@ -3415,10 +3474,44 @@ NextCopyFrom(CopyState cstate, ExprContext *econtext,
 
 			cstate->cur_attname = NameStr(att->attname);
 			cstate->cur_attval = string;
+
+            /*
+             * Catch errors inside InputFunctionCall to handle
+             * errors due to the type invalid syntax.
+             */
+            PG_TRY();
+            {
 			values[m] = InputFunctionCall(&in_functions[m],
 										  string,
 										  typioparams[m],
 										  att->atttypmod);
+            }
+            PG_CATCH();
+            {
+            if (cstate->ignore_errors)
+            {
+                ErrorData  *edata;
+
+                /* Save error info */
+                MemoryContextSwitchTo(oldcontext);
+                edata = CopyErrorData();
+                FlushErrorState();
+
+                /* TODO Find an appropriate errcode */
+                /* Propagate catched ERROR sqlerrcode and message as WARNING */
+                ereport(WARNING,
+                        (errcode(edata->sqlerrcode),
+                         errmsg("%s at line %d col %d", edata->message, cstate->cur_lineno, attnum)));
+                return NCF_SKIP;
+            }
+            else
+            {
+                /* Propagate ERROR as is if errors handling is not turned on */
+                PG_RE_THROW();
+            }
+            }
+            PG_END_TRY();
+
 			if (string != NULL)
 				nulls[m] = false;
 			cstate->cur_attname = NULL;
@@ -3438,7 +3531,7 @@ NextCopyFrom(CopyState cstate, ExprContext *econtext,
 		if (!CopyGetInt16(cstate, &fld_count))
 		{
 			/* EOF detected (end of file, or protocol-level EOF) */
-			return false;
+			return NCF_STOP;
 		}
 
 		if (fld_count == -1)
@@ -3462,14 +3555,17 @@ NextCopyFrom(CopyState cstate, ExprContext *econtext,
 				ereport(ERROR,
 						(errcode(ERRCODE_BAD_COPY_FILE_FORMAT),
 						 errmsg("received copy data after EOF marker")));
-			return false;
+			return NCF_STOP;
 		}
 
 		if (fld_count != attr_count)
-			ereport(ERROR,
+        {
+			ereport(error_level,
 					(errcode(ERRCODE_BAD_COPY_FILE_FORMAT),
 					 errmsg("row field count is %d, expected %d",
 							(int) fld_count, attr_count)));
+            return NCF_SKIP;
+        }
 
 		if (file_has_oids)
 		{
@@ -3484,9 +3580,12 @@ NextCopyFrom(CopyState cstate, ExprContext *econtext,
 														 -1,
 														 &isnull));
 			if (isnull || loaded_oid == InvalidOid)
-				ereport(ERROR,
+            {
+				ereport(error_level,
 						(errcode(ERRCODE_BAD_COPY_FILE_FORMAT),
 						 errmsg("invalid OID in COPY data")));
+                return NCF_SKIP;
+            }
 			cstate->cur_attname = NULL;
 			if (cstate->oids && tupleOid != NULL)
 				*tupleOid = loaded_oid;
@@ -3529,7 +3628,7 @@ NextCopyFrom(CopyState cstate, ExprContext *econtext,
 										 &nulls[defmap[i]]);
 	}
 
-	return true;
+	return NCF_SUCCESS;
 }
 
 /*

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -639,7 +639,7 @@ static Node *makeRecursiveViewSelect(char *relname, List *aliases, Node *query);
 	IDENTITY_P IF_P ILIKE IMMEDIATE IMMUTABLE IMPLICIT_P IMPORT_P IN_P
 	INCLUDING INCREMENT INDEX INDEXES INHERIT INHERITS INITIALLY INLINE_P
 	INNER_P INOUT INPUT_P INSENSITIVE INSERT INSTEAD INT_P INTEGER
-	INTERSECT INTERVAL INTO INVOKER IS ISNULL ISOLATION
+	INTERSECT INTERVAL INTO INVOKER IS ISNULL ISOLATION IGNORE_ERRORS
 
 	JOIN
 
@@ -3073,6 +3073,10 @@ copy_opt_item:
 			| ENCODING Sconst
 				{
 					$$ = makeDefElem("encoding", (Node *)makeString($2), @1);
+				}
+			| IGNORE_ERRORS
+				{
+					$$ = makeDefElem("ignore_errors", (Node *)makeInteger(true), @1);
 				}
 		;
 

--- a/src/include/commands/copy.h
+++ b/src/include/commands/copy.h
@@ -31,7 +31,7 @@ extern void ProcessCopyOptions(ParseState *pstate, CopyState cstate, bool is_fro
 extern CopyState BeginCopyFrom(ParseState *pstate, Relation rel, const char *filename,
 			  bool is_program, copy_data_source_cb data_source_cb, List *attnamelist, List *options);
 extern void EndCopyFrom(CopyState cstate);
-extern bool NextCopyFrom(CopyState cstate, ExprContext *econtext,
+extern int NextCopyFrom(CopyState cstate, ExprContext *econtext,
 			 Datum *values, bool *nulls, Oid *tupleOid);
 extern bool NextCopyFromRawFields(CopyState cstate,
 					  char ***fields, int *nfields);

--- a/src/test/regress/expected/alter_table.out
+++ b/src/test/regress/expected/alter_table.out
@@ -1455,7 +1455,7 @@ ERROR:  column "a" of relation "test" does not exist
 copy test("........pg.dropped.1........") to stdout;
 ERROR:  column "........pg.dropped.1........" of relation "test" does not exist
 copy test from stdin;
-ERROR:  extra data after last expected column
+ERROR:  extra data after last expected column at line 1
 CONTEXT:  COPY test, line 1: "10	11	12"
 select * from test;
  b | c 

--- a/src/test/regress/expected/copy2.out
+++ b/src/test/regress/expected/copy2.out
@@ -36,15 +36,26 @@ COPY x from stdin;
 ERROR:  invalid input syntax for integer: ""
 CONTEXT:  COPY x, line 1, column a: ""
 COPY x from stdin;
-ERROR:  missing data for column "e"
+ERROR:  missing data for column "e" at line 1
 CONTEXT:  COPY x, line 1: "2000	230	23	23"
 COPY x from stdin;
-ERROR:  missing data for column "e"
+ERROR:  missing data for column "e" at line 1
 CONTEXT:  COPY x, line 1: "2001	231	\N	\N"
 -- extra data: should fail
 COPY x from stdin;
-ERROR:  extra data after last expected column
+ERROR:  extra data after last expected column at line 1
 CONTEXT:  COPY x, line 1: "2002	232	40	50	60	70	80"
+-- missing data: should be able to ignore errors
+COPY x from stdin with (ignore_errors);
+WARNING:  missing data for column "e" at line 1
+COPY x from stdin with (ignore_errors);
+WARNING:  missing data for column "e" at line 1
+-- extra data: should be able to ignore errors
+COPY x from stdin with (ignore_errors);
+WARNING:  extra data after last expected column at line 1
+-- data type inappropriate format: should be able to ignore errors
+COPY x from stdin with (ignore_errors);
+WARNING:  invalid input syntax for integer: "'24'" at line 2 col 2
 -- various COPY options: delimiters, oids, NULL string, encoding
 COPY x (b, c, d, e) from stdin with oids delimiter ',' null 'x';
 COPY x from stdin WITH DELIMITER AS ';' NULL AS '';
@@ -60,6 +71,10 @@ SELECT * FROM x;
  10003 | 24 | 34         | 44     | before trigger fired
  10004 | 25 | 35         | 45     | before trigger fired
  10005 | 26 | 36         | 46     | before trigger fired
+  2004 | 27 | 37         | 47     | before trigger fired
+  2006 | 28 | 38         | 48     | before trigger fired
+  2008 | 29 | 39         | 49     | before trigger fired
+  2009 | 30 | 40         | 50     | before trigger fired
      6 |    | 45         | 80     | before trigger fired
      7 |    | x          | \x     | before trigger fired
      8 |    | ,          | \,     | before trigger fired
@@ -78,7 +93,7 @@ SELECT * FROM x;
      3 |  3 | stuff      | test_3 | after trigger fired
      4 |  4 | stuff      | test_4 | after trigger fired
      5 |  5 | stuff      | test_5 | after trigger fired
-(25 rows)
+(29 rows)
 
 -- COPY w/ oids on a table w/o oids should fail
 CREATE TABLE no_oids (
@@ -101,6 +116,10 @@ COPY x TO stdout;
 10003	24	34	44	before trigger fired
 10004	25	35	45	before trigger fired
 10005	26	36	46	before trigger fired
+2004	27	37	47	before trigger fired
+2006	28	38	48	before trigger fired
+2008	29	39	49	before trigger fired
+2009	30	40	50	before trigger fired
 6	\N	45	80	before trigger fired
 7	\N	x	\\x	before trigger fired
 8	\N	,	\\,	before trigger fired
@@ -127,6 +146,10 @@ COPY x (c, e) TO stdout;
 34	before trigger fired
 35	before trigger fired
 36	before trigger fired
+37	before trigger fired
+38	before trigger fired
+39	before trigger fired
+40	before trigger fired
 45	before trigger fired
 x	before trigger fired
 ,	before trigger fired
@@ -153,6 +176,10 @@ I'm null	before trigger fired
 24	before trigger fired
 25	before trigger fired
 26	before trigger fired
+27	before trigger fired
+28	before trigger fired
+29	before trigger fired
+30	before trigger fired
 I'm null	before trigger fired
 I'm null	before trigger fired
 I'm null	before trigger fired

--- a/src/test/regress/sql/copy2.sql
+++ b/src/test/regress/sql/copy2.sql
@@ -72,6 +72,29 @@ COPY x from stdin;
 2002	232	40	50	60	70	80
 \.
 
+-- missing data: should be able to ignore errors
+COPY x from stdin with (ignore_errors);
+2003	230	23	23
+2004	27	37	47	57
+\.
+COPY x from stdin with (ignore_errors);
+2005	231	\N	\N
+2006	28	38	48	58
+\.
+
+-- extra data: should be able to ignore errors
+COPY x from stdin with (ignore_errors);
+2007	232	40	50	60	70	80
+2008	29	39	49	59
+\.
+
+-- data type inappropriate format: should be able to ignore errors
+
+COPY x from stdin with (ignore_errors);
+2009	30	40	50	60
+2010	'24'	34	44	54
+\.
+
 -- various COPY options: delimiters, oids, NULL string, encoding
 COPY x (b, c, d, e) from stdin with oids delimiter ',' null 'x';
 500000,x,45,80,90


### PR DESCRIPTION
Rebased and squashed version of https://github.com/ololobus/postgres/pull/3

Report line number on each ERROR/WARNING

Catch errors at InputFunctionCall inside NextCopyFrom

Tabs vs spaces consistency

Fixed possible Segmentation fault during malformed lines processing

Propagate catched SQL error code to warning

IGNORE_ERRORS COPY SQL option added (only new syntax supported)

Regression test updated to handle new COPY functionality

Fixed parser and rebase typo