### PR TITLE
pg_rewind: Add options to restore WAL files from archive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: c
+compiler: gcc
+dist: xenial
+addons:
+  apt:
+    packages:
+    - libreadline-dev
+    - zlib1g-dev
+install:
+  - curl -L https://cpanmin.us | perl - App::cpanminus
+  - ~/perl5/bin/cpanm --local-lib=~/perl5 local::lib && eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
+  - ~/perl5/bin/cpanm IPC::Run
+  - ~/perl5/bin/cpanm Test::More
+  - ~/perl5/bin/cpanm Time::HiRes
+script:
+  - export CFLAGS="-Og"
+  - ./configure --enable-debug --enable-cassert --enable-depend --enable-tap-tests BISONFLAGS="-v"
+  - make check-world

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# PostgreSQL mirror
+[![Travis-ci Status](https://travis-ci.org/ololobus/postgres.svg?branch=master)](https://travis-ci.org/ololobus/postgres)
+[![Appveyor Status](https://ci.appveyor.com/api/projects/status/f42li9kqurfc3gjt/branch/master?svg=true)](https://ci.appveyor.com/project/ololobus/postgres)
+
+Involves automatic builds of PRs/commits on Linux (Travis-CI) and Windows (Appveyor):
+  * Linux: full `make check-world`
+  * Windows: only build + `make check`
+
+For original PostgreSQL readme [refer to README file](README).

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,32 @@
+skip_branch_with_pr: true
+shallow_clone: true
+
+image:
+  - Visual Studio 2015
+
+install:
+  - appveyor-retry cinst winflexbison
+  - '"C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64'
+  - '"C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" x86_amd64'
+
+before_build:
+  - rename c:\ProgramData\chocolatey\bin\win_flex.exe flex.exe
+  - rename c:\ProgramData\chocolatey\bin\win_bison.exe bison.exe
+  # - cpan App::cpanminus
+  # - cpanm CPAN
+  # - cpanm Test::More
+  # - cpanm Time::HiRes
+  # - cpanm --notest --no-prompt -f IPC::Run # There are some problems with running IPC::Run tests on install
+  - perl buildsetup.pl
+
+build:
+  project: pgsql.sln
+
+test_script:
+  - cd src\tools\msvc && vcregress check #&& vcregress bincheck
+
+on_failure:
+  - perl dumpregr.pl
+
+configuration:
+  - Release

--- a/buildsetup.pl
+++ b/buildsetup.pl
@@ -1,0 +1,42 @@
+# First part of postgres build.pl, just doesn't run msbuild
+
+use strict;
+
+use File::Copy;
+
+BEGIN
+{
+
+    chdir("../../..") if (-d "../msvc" && -d "../../../src");
+
+}
+
+use lib "src/tools/msvc";
+
+use Cwd;
+
+use Mkvcbuild;
+
+# buildenv.pl is for specifying the build environment settings
+# it should contain lines like:
+# $ENV{PATH} = "c:/path/to/bison/bin;$ENV{PATH}";
+
+if (-e "src/tools/msvc/buildenv.pl")
+{
+    do "src/tools/msvc/buildenv.pl";
+}
+elsif (-e "./buildenv.pl")
+{
+    do "./buildenv.pl";
+}
+
+copy("config.pl", "src/tools/msvc/config.pl");
+
+# set up the project
+our $config;
+do "config_default.pl";
+do "config.pl" if (-f "src/tools/msvc/config.pl");
+
+# print "PATH: $_\n" foreach (split(';',$ENV{PATH}));
+
+Mkvcbuild::mkvcbuild($config);

--- a/config.pl
+++ b/config.pl
@@ -1,0 +1,32 @@
+# Configuration arguments for vcbuild.
+use strict;
+use warnings;
+
+our $config = {
+	asserts => 1,    # --enable-cassert
+	# float4byval=>1,         # --disable-float4-byval, on by default
+
+	# float8byval=> $platformbits == 64, # --disable-float8-byval,
+	# off by default on 32 bit platforms, on by default on 64 bit platforms
+
+	# blocksize => 8,         # --with-blocksize, 8kB by default
+	# wal_blocksize => 8,     # --with-wal-blocksize, 8kB by default
+	# wal_segsize => 16,      # --with-wal-segsize, 16MB by default
+	ldap      => 1,        # --with-ldap
+	extraver  => undef,    # --with-extra-version=<string>
+	gss       => undef,    # --with-gssapi=<path>
+	icu       => undef,    # --with-icu=<path>
+	nls       => undef,    # --enable-nls=<path>
+	tap_tests => 1,        # --enable-tap-tests
+	tcl       => undef,    # --with-tcl=<path>
+	perl      => undef,    # --with-perl
+	python    => undef,    # --with-python=<path>
+	openssl   => undef,    # --with-openssl=<path>
+	uuid      => undef,    # --with-ossp-uuid
+	xml       => undef,    # --with-libxml=<path>
+	xslt      => undef,    # --with-libxslt=<path>
+	iconv     => undef,    # (not in configure, path to iconv)
+	zlib      => undef     # --with-zlib=<path>
+};
+
+1;

--- a/doc/src/sgml/ref/pg_rewind.sgml
+++ b/doc/src/sgml/ref/pg_rewind.sgml
@@ -66,11 +66,11 @@ PostgreSQL documentation
    can be found either on the target timeline, the source timeline, or their common
    ancestor. In the typical failover scenario where the target cluster was
    shut down soon after the divergence, this is not a problem, but if the
-   target cluster ran for a long time after the divergence, the old WAL
-   files might no longer be present. In that case, they can be manually
-   copied from the WAL archive to the <filename>pg_wal</filename> directory, or
-   fetched on startup by configuring <xref linkend="guc-primary-conninfo"/> or
-   <xref linkend="guc-restore-command"/>.  The use of
+   target cluster ran for a long time after the divergence, its old WAL
+   files might no longer be present. In this case, you can manually copy them
+   from the WAL archive to the <filename>pg_wal</filename> directory, or run
+   <application>pg_rewind</application> with the <literal>-c</literal> option to
+   automatically retrieve them from the WAL archive. The use of
    <application>pg_rewind</application> is not limited to failover, e.g.  a standby
    server can be promoted, run some write transactions, and then rewinded
    to become a standby again.
@@ -233,6 +233,19 @@ PostgreSQL documentation
      </varlistentry>
 
      <varlistentry>
+      <term><option>-c</option></term>
+      <term><option>--restore-target-wal</option></term>
+      <listitem>
+       <para>
+        Use the <varname>restore_command</varname> defined in
+        <filename>postgresql.conf</filename> to retrieve WAL files from
+        the WAL archive if these files are no longer available in the
+        <filename>pg_wal</filename> directory of the target cluster.
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry>
       <term><option>--debug</option></term>
       <listitem>
        <para>
@@ -318,7 +331,10 @@ GRANT EXECUTE ON function pg_catalog.pg_read_binary_file(text, bigint, bigint, b
       history forked off from the target cluster. For each WAL record,
       record each data block that was touched. This yields a list of all
       the data blocks that were changed in the target cluster, after the
-      source cluster forked off.
+      source cluster forked off. If some of the WAL files are no longer
+      available, try re-running <application>pg_rewind</application> with
+      the <option>-c</option> option to search for the missing files in
+      the WAL archive.
      </para>
     </step>
     <step>

--- a/dumpregr.pl
+++ b/dumpregr.pl
@@ -1,0 +1,21 @@
+use strict;
+use warnings FATAL => qw(all);
+
+use File::Find;
+
+my $Target = "regression.diffs";
+
+find(\&dump, "src");
+
+sub dump {
+  if ($_ eq $Target) {
+    my $path = $File::Find::name;
+    print "=== \$path ===\\n";
+    open(my $fh, "<", $_) || die "wtf";
+    for (1..1000) {
+      my $line = <$fh>;
+      last unless defined $line;
+      print $line;
+    }
+  }
+}

--- a/src/bin/pg_rewind/parsexlog.c
+++ b/src/bin/pg_rewind/parsexlog.c
@@ -19,6 +19,7 @@
 #include "catalog/pg_control.h"
 #include "catalog/storage_xlog.h"
 #include "commands/dbcommands_xlog.h"
+#include "common/fe_archive.h"
 #include "filemap.h"
 #include "pg_rewind.h"
 
@@ -41,6 +42,7 @@ static char xlogfpath[MAXPGPATH];
 
 typedef struct XLogPageReadPrivate
 {
+	const char *restoreCommand;
 	int			tliIndex;
 } XLogPageReadPrivate;
 
@@ -55,7 +57,7 @@ static int	SimpleXLogPageRead(XLogReaderState *xlogreader,
  */
 void
 extractPageMap(const char *datadir, XLogRecPtr startpoint, int tliIndex,
-			   XLogRecPtr endpoint)
+			   XLogRecPtr endpoint, const char *restore_command)
 {
 	XLogRecord *record;
 	XLogReaderState *xlogreader;
@@ -63,6 +65,7 @@ extractPageMap(const char *datadir, XLogRecPtr startpoint, int tliIndex,
 	XLogPageReadPrivate private;
 
 	private.tliIndex = tliIndex;
+	private.restoreCommand = restore_command;
 	xlogreader = XLogReaderAllocate(WalSegSz, datadir, &SimpleXLogPageRead,
 									&private);
 	if (xlogreader == NULL)
@@ -146,7 +149,7 @@ readOneRecord(const char *datadir, XLogRecPtr ptr, int tliIndex)
 void
 findLastCheckpoint(const char *datadir, XLogRecPtr forkptr, int tliIndex,
 				   XLogRecPtr *lastchkptrec, TimeLineID *lastchkpttli,
-				   XLogRecPtr *lastchkptredo)
+				   XLogRecPtr *lastchkptredo, const char *restoreCommand)
 {
 	/* Walk backwards, starting from the given record */
 	XLogRecord *record;
@@ -170,6 +173,7 @@ findLastCheckpoint(const char *datadir, XLogRecPtr forkptr, int tliIndex,
 	}
 
 	private.tliIndex = tliIndex;
+	private.restoreCommand = restoreCommand;
 	xlogreader = XLogReaderAllocate(WalSegSz, datadir, &SimpleXLogPageRead,
 									&private);
 	if (xlogreader == NULL)
@@ -281,8 +285,29 @@ SimpleXLogPageRead(XLogReaderState *xlogreader, XLogRecPtr targetPagePtr,
 
 		if (xlogreadfd < 0)
 		{
-			pg_log_error("could not open file \"%s\": %m", xlogfpath);
-			return -1;
+			/*
+			 * If we have no restore_command to execute, then exit.
+			 */
+			if (private->restoreCommand == NULL)
+			{
+				pg_log_error("could not open file \"%s\": %m", xlogfpath);
+				return -1;
+			}
+
+			/*
+			 * Since we have restore_command to execute, then try to retrieve
+			 * missing WAL file from the archive.
+			 */
+			xlogreadfd = RestoreArchivedWALFile(xlogreader->segcxt.ws_dir,
+												xlogfname,
+												WalSegSz,
+												private->restoreCommand);
+
+			if (xlogreadfd < 0)
+				return -1;
+			else
+				pg_log_debug("using file \"%s\" restored from archive",
+							 xlogfpath);
 		}
 	}
 

--- a/src/bin/pg_rewind/pg_rewind.h
+++ b/src/bin/pg_rewind/pg_rewind.h
@@ -42,11 +42,13 @@ extern uint64 fetch_done;
 
 /* in parsexlog.c */
 extern void extractPageMap(const char *datadir, XLogRecPtr startpoint,
-						   int tliIndex, XLogRecPtr endpoint);
+						   int tliIndex, XLogRecPtr endpoint,
+						   const char *restoreCommand);
 extern void findLastCheckpoint(const char *datadir, XLogRecPtr searchptr,
 							   int tliIndex,
 							   XLogRecPtr *lastchkptrec, TimeLineID *lastchkpttli,
-							   XLogRecPtr *lastchkptredo);
+							   XLogRecPtr *lastchkptredo,
+							   const char *restoreCommand);
 extern XLogRecPtr readOneRecord(const char *datadir, XLogRecPtr ptr,
 								int tliIndex);
 

--- a/src/bin/pg_rewind/t/001_basic.pl
+++ b/src/bin/pg_rewind/t/001_basic.pl
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 use TestLib;
-use Test::More tests => 15;
+use Test::More tests => 20;
 
 use FindBin;
 use lib $FindBin::RealBin;
@@ -171,5 +171,6 @@ in master, before promotion
 # Run the test in both modes
 run_test('local');
 run_test('remote');
+run_test('archive');
 
 exit(0);

--- a/src/common/Makefile
+++ b/src/common/Makefile
@@ -47,6 +47,7 @@ LIBS += $(PTHREAD_LIBS)
 # If you add objects here, see also src/tools/msvc/Mkvcbuild.pm
 
 OBJS_COMMON = \
+	archive.o \
 	base64.o \
 	config_info.o \
 	controldata_utils.o \
@@ -87,6 +88,7 @@ endif
 # (Mkvcbuild.pm has a copy of this list, too)
 OBJS_FRONTEND = \
 	$(OBJS_COMMON) \
+	fe_archive.o \
 	fe_memutils.o \
 	file_utils.o \
 	logging.o \

--- a/src/common/archive.c
+++ b/src/common/archive.c
@@ -1,0 +1,97 @@
+/*-------------------------------------------------------------------------
+ *
+ * archive.c
+ *	  Common WAL archive routines
+ *
+ * Copyright (c) 2020, PostgreSQL Global Development Group
+ *
+ *
+ * IDENTIFICATION
+ *	  src/common/archive.c
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "common/archive.h"
+
+/*
+ * Constructs restore_command from template with %p, %f and %r aliases.
+ * Returns 0 if restore_command was successfuly built.
+ *
+ * If any of the required arguments is NULL, but corresponding alias is
+ * met, then -1 code will be returned.
+ */
+int
+ConstructRestoreCommand(const char *restoreCommand,
+						const char *xlogpath,
+						const char *xlogfname,
+						const char *lastRestartPointFname,
+						char *result)
+{
+	char	   *dp,
+			   *endp;
+	const char *sp;
+
+	/*
+	 * Construct the command to be executed.
+	 */
+	dp = result;
+	endp = result + MAXPGPATH - 1;
+	*endp = '\0';
+
+	for (sp = restoreCommand; *sp; sp++)
+	{
+		if (*sp == '%')
+		{
+			switch (sp[1])
+			{
+				case 'p':
+					/* %p: relative path of target file */
+					if (xlogpath == NULL)
+						return -1;
+					sp++;
+					StrNCpy(dp, xlogpath, endp - dp);
+					make_native_path(dp);
+					dp += strlen(dp);
+					break;
+				case 'f':
+					/* %f: filename of desired file */
+					if (xlogfname == NULL)
+						return -1;
+					sp++;
+					StrNCpy(dp, xlogfname, endp - dp);
+					dp += strlen(dp);
+					break;
+				case 'r':
+					/* %r: filename of last restartpoint */
+					if (lastRestartPointFname == NULL)
+						return -1;
+					sp++;
+					StrNCpy(dp, lastRestartPointFname, endp - dp);
+					dp += strlen(dp);
+					break;
+				case '%':
+					/* convert %% to a single % */
+					sp++;
+					if (dp < endp)
+						*dp++ = *sp;
+					break;
+				default:
+					/* otherwise treat the % as not special */
+					if (dp < endp)
+						*dp++ = *sp;
+					break;
+			}
+		}
+		else
+		{
+			if (dp < endp)
+				*dp++ = *sp;
+		}
+	}
+	*dp = '\0';
+
+	return 0;
+}

--- a/src/common/fe_archive.c
+++ b/src/common/fe_archive.c
@@ -1,0 +1,106 @@
+/*-------------------------------------------------------------------------
+ *
+ * fe_archive.c
+ *	  Routines to access WAL archive from frontend
+ *
+ * Copyright (c) 2020, PostgreSQL Global Development Group
+ *
+ *
+ * IDENTIFICATION
+ *	  src/common/fe_archive.c
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres_fe.h"
+
+#include <unistd.h>
+#include <sys/stat.h>
+
+#include "access/xlog_internal.h"
+#include "common/archive.h"
+#include "common/fe_archive.h"
+#include "common/logging.h"
+
+
+/* logging support */
+#define pg_fatal(...) do { pg_log_fatal(__VA_ARGS__); exit(1); } while(0)
+
+/*
+ * Attempt to retrieve the specified file from off-line archival storage.
+ * If successful return a file descriptor of the restored WAL file, else
+ * return -1.
+ *
+ * For fixed-size files, the caller may pass the expected size as an
+ * additional crosscheck on successful recovery.  If the file size is not
+ * known, set expectedSize = 0.
+ */
+int
+RestoreArchivedWALFile(const char *path, const char *xlogfname,
+					   off_t expectedSize, const char *restoreCommand)
+{
+	char		xlogpath[MAXPGPATH],
+				xlogRestoreCmd[MAXPGPATH];
+	int			rc,
+				xlogfd;
+	struct stat stat_buf;
+
+	snprintf(xlogpath, MAXPGPATH, "%s/" XLOGDIR "/%s", path, xlogfname);
+
+	rc = ConstructRestoreCommand(restoreCommand, xlogpath, xlogfname, NULL, xlogRestoreCmd);
+
+	if (rc < 0)
+		pg_fatal("restore_command with %%r alias cannot be used.");
+
+	/*
+	 * Execute restore_command, which should copy the missing WAL file from
+	 * archival storage.
+	 */
+	rc = system(xlogRestoreCmd);
+
+	if (rc == 0)
+	{
+		/*
+		 * Command apparently succeeded, but let's make sure the file is
+		 * really there now and has the correct size.
+		 */
+		if (stat(xlogpath, &stat_buf) == 0)
+		{
+			if (expectedSize > 0 && stat_buf.st_size != expectedSize)
+			{
+				pg_log_error("archive file \"%s\" has wrong size: %lu instead of %lu, %s",
+							 xlogfname, (unsigned long) stat_buf.st_size,
+							 (unsigned long) expectedSize, strerror(errno));
+			}
+			else
+			{
+				xlogfd = open(xlogpath, O_RDONLY | PG_BINARY, 0);
+
+				if (xlogfd < 0)
+					pg_log_error("could not open file \"%s\" restored from archive: %s\n",
+								 xlogpath, strerror(errno));
+				else
+					return xlogfd;
+			}
+		}
+		else
+		{
+			/* Stat failed */
+			pg_log_error("could not stat file \"%s\" restored from archive: %s",
+						 xlogpath, strerror(errno));
+		}
+	}
+
+	/*
+	 * If the failure was due to any sort of signal, then it will be
+	 * misleading to return message 'could not restore file...' and propagate
+	 * result to the upper levels. We should exit right now.
+	 */
+	if (wait_result_is_any_signal(rc, false))
+		pg_fatal("restore_command failed due to the signal: %s",
+				 wait_result_to_str(rc));
+
+	pg_log_error("could not restore file \"%s\" from archive\n",
+				 xlogfname);
+	return -1;
+}

--- a/src/include/common/archive.h
+++ b/src/include/common/archive.h
@@ -1,0 +1,21 @@
+/*-------------------------------------------------------------------------
+ *
+ * archive.h
+ *	  Common WAL archive routines
+ *
+ * Copyright (c) 2020, PostgreSQL Global Development Group
+ *
+ * src/include/common/archive.h
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef ARCHIVE_H
+#define ARCHIVE_H
+
+extern int ConstructRestoreCommand(const char *restoreCommand,
+								   const char *xlogpath,
+								   const char *xlogfname,
+								   const char *lastRestartPointFname,
+								   char *result);
+
+#endif							/* ARCHIVE_H */

--- a/src/include/common/fe_archive.h
+++ b/src/include/common/fe_archive.h
@@ -1,0 +1,18 @@
+/*-------------------------------------------------------------------------
+ *
+ * fe_archive.h
+ *	  Routines to access WAL archive from frontend
+ *
+ * Copyright (c) 2020, PostgreSQL Global Development Group
+ *
+ * src/include/common/fe_archive.h
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef FE_ARCHIVE_H
+#define FE_ARCHIVE_H
+
+extern int RestoreArchivedWALFile(const char *path, const char *xlogfname,
+								  off_t expectedSize, const char *restoreCommand);
+
+#endif							/* FE_ARCHIVE_H */

--- a/src/tools/msvc/Mkvcbuild.pm
+++ b/src/tools/msvc/Mkvcbuild.pm
@@ -120,8 +120,8 @@ sub mkvcbuild
 	}
 
 	our @pgcommonallfiles = qw(
-	  base64.c config_info.c controldata_utils.c d2s.c encnames.c exec.c
-	  f2s.c file_perm.c ip.c jsonapi.c
+	  archive.c base64.c config_info.c controldata_utils.c d2s.c encnames.c
+	  exec.c f2s.c file_perm.c ip.c jsonapi.c
 	  keywords.c kwlookup.c link-canary.c md5.c
 	  pg_lzcompress.c pgfnames.c psprintf.c relpath.c rmtree.c
 	  saslprep.c scram-common.c string.c stringinfo.c unicode_norm.c username.c
@@ -138,8 +138,8 @@ sub mkvcbuild
 	}
 
 	our @pgcommonfrontendfiles = (
-		@pgcommonallfiles, qw(fe_memutils.c file_utils.c
-		  logging.c restricted_token.c));
+		@pgcommonallfiles, qw(fe_archive.c fe_memutils.c
+		  file_utils.c logging.c restricted_token.c));
 
 	our @pgcommonbkndfiles = @pgcommonallfiles;
 


### PR DESCRIPTION
    Currently, pg_rewind fails when it could not find required WAL files in the
    target data directory.  One have to manually figure out which WAL files are
    required and copy them back from archive.

    This commit implements two new pg_rewind options, which allow pg_rewind to
    automatically retrieve missing WAL files from archival storage.  The first
    option let pg_rewind read restore_command from postgresql.conf, while the
    second one specifies restore_command directly.

    Discussion: https://postgr.es/m/a3acff50-5a0d-9a2c-b3b2-ee36168955c1%40postgrespro.ru
    Author: Alexey Kondratov
    Reviewed-by: Andrey Borodin, Alvaro Herrera, Michael Paquier
    Reviewed-by: Andres Freund, Alexander Korotkov